### PR TITLE
feat: /observations/to-element/:id

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ multiple results.
 Update an observation by its `id` by providing a JSON object. Any fields given
 will be replaced.
 
+#### `PUT /observations/to-element/:id`
+
+Converts an observation, by its ID, to an OSM element (defaults to `node`
+currently). Returns an object of the form `{ id: elementId }`. If the
+observation has already been converted to a node, it will return the existing
+ID.
+
 ### Presets
 
 #### `GET /presets`

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function (osm, media, opts) {
   router.addRoute('GET /observations/:id',     api.observationGet.bind(api))
   router.addRoute('POST /observations',        api.observationCreate.bind(api))
   router.addRoute('PUT /observations/:id',     api.observationUpdate.bind(api))
-  router.addRoute('DELETE /observations/:id',     api.observationDelete.bind(api))
+  router.addRoute('DELETE /observations/:id',  api.observationDelete.bind(api))
+  router.addRoute('PUT /observations/to-element/:id', api.observationConvert.bind(api))
 
   // Presets
   router.addRoute('GET /presets',              api.presetsList.bind(api))

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "ecstatic": "^3.2.0",
     "mapeo-sync": "^1.0.2",
     "randombytes": "^2.0.6",
-    "routes": "^2.1.0"
+    "routes": "^2.1.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.3.4",

--- a/test/observations.js
+++ b/test/observations.js
@@ -171,6 +171,41 @@ test('observations: create + update', function (t) {
   })
 })
 
+test('observations: create + convert', function (t) {
+  createServer(function (server, base, osm, media) {
+    var og = {
+      lat: 1,
+      lon: 2,
+      type: 'observation',
+      created_at_timestamp: new Date().getTime()
+    }
+    osm.create(og, function (err, id, node) {
+      t.error(err)
+
+      // convert to node
+      putJson(`${base}/observations/to-element/${id}`, function (err, elm) {
+        t.error(err)
+        t.ok(elm.id)
+
+        // look up observation again + check for element_id tag
+        getJson(`${base}/observations/${id}`, function (err, obses) {
+          t.error(err)
+          t.equals(obses[0].tags.element_id, elm.id)
+
+          // look up element + check id
+          getJson(`${base}/observations/${elm.id}`, function (err, theElms) {
+            t.error(err)
+            t.equals(theElms[0].id, elm.id)
+
+            server.close()
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
 function check (t, href, expected, done) {
   var hq = hyperquest.get(href, {
     headers: { 'content-type': 'application/json' }
@@ -192,4 +227,31 @@ function check (t, href, expected, done) {
     }
     done()
   }))
+}
+
+function putJson (href, cb) {
+  var hq = hyperquest.put(href, { headers: { 'content-type': 'application/json' } })
+  hq.on('response', function (res) {
+    if (res.statusCode === 200) {
+      hq.pipe(concat({ encoding: 'string' }, function (body) {
+        cb(null, JSON.parse(body))
+      }))
+    } else {
+      cb(res.statusCode)
+    }
+  })
+  hq.end()
+}
+
+function getJson (href, cb) {
+  var hq = hyperquest.get(href, { headers: { 'content-type': 'application/json' } })
+  hq.on('response', function (res) {
+    if (res.statusCode === 200) {
+      hq.pipe(concat({ encoding: 'string' }, function (body) {
+        cb(null, JSON.parse(body))
+      }))
+    } else {
+      cb(res.statusCode)
+    }
+  })
 }


### PR DESCRIPTION
Creates a new OSM node with the data contained in the observation named by `:id`. The observation is modified to have a tag named `element_id` that refers to the ID of the newly created OSM node.