### PR TITLE
fix: it is valid for observations to have no lat/lon

### DIFF
--- a/api.js
+++ b/api.js
@@ -81,11 +81,6 @@ Api.prototype.observationCreate = function (req, res, m) {
       res.end('couldnt parse body json: ' + err.toString())
       return
     }
-    if (obs.lat === undefined || obs.lon === undefined) {
-      res.statusCode = 400
-      res.end('observation must have "lat" and "lon" fields')
-      return
-    }
 
     obs.type = 'observation'
     obs.created_at_timestamp = (new Date().getTime())

--- a/test/observations.js
+++ b/test/observations.js
@@ -61,25 +61,6 @@ test('observations: create + delete', function (t) {
   })
 })
 
-test('observations: create invalid', function (t) {
-  createServer(function (server, base) {
-    var href = base + '/observations'
-
-    var hq = hyperquest.post(href, {
-      headers: { 'content-type': 'application/json' }
-    })
-
-    // http response
-    hq.once('response', function (res) {
-      t.equal(res.statusCode, 400, 'create 400 bad')
-      server.close()
-      t.end()
-    })
-
-    hq.end(JSON.stringify({dog: 5, lon: -0.123}))
-  })
-})
-
 test('observations: create + get', function (t) {
   createServer(function (server, base, osm, media) {
     osm.create({lat:1,lon:2,type:'observation'}, function (err, id, node) {


### PR DESCRIPTION
from @gregor:
'Geometry can be null. That is the same with Mapeo, we can have observations with geometry null (no lat/lon). I think they should still be synced to Mapeo Desktop. They will not appear on the map, but the photos and data should appear in the photo and report views. We need to implement a list view in Mapeo / Mapfilter at some point'