### PR TITLE
(BREAKING) Allow thumbnail uploads /w original media

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,11 @@ to the database. `PATH` should be URL encoded.
 
 Optionally, a thumbnail file path may also be included.
 
-A single JSON object is returned, with the base `id`, the original image's ID, and, if a thumbnail as given, the thumbnail ID:
+A single JSON object is returned, with the media's unique `id`:
 
 ```json
 {
   "id": "225961fb85d82312e8c0ed511.jpg",
-  "original": "original/225961fb85d82312e8c0ed511.jpg",
-  "thumbnail": "thumbnail/225961fb85d82312e8c0ed511.jpg"
 }
 ```
 
@@ -98,7 +96,15 @@ To fetch the thumbnail later, one would hit the route `GET /media/thumbnail/2259
 
 #### `GET /media/:type/:id`
 
-Retrieve a piece of media (photos only for now) by its `id`. Valid `type`s are `original` and `thumbnail`.
+Retrieve a piece of media (photos only for now) by its `id`. Valid `type`s are `original` and `thumbnail`. e.g.
+
+```
+GET /media/thumbnail/225961fb85d82312e8c0ed511.jpg
+```
+or
+```
+GET /media/original/225961fb85d82312e8c0ed511.jpg
+```
 
 ### Mapbox Styles & Tiles
 

--- a/README.md
+++ b/README.md
@@ -77,24 +77,28 @@ Fetch a static file belonging to a preset with id `id`.
 
 ### Media
 
-#### `PUT /media?file=PATH`
+#### `PUT /media?file=PATH&thumbnail=PATH
 
 Save a piece of media (photos only), identified by the absolute file path `PATH`
 to the database. `PATH` should be URL encoded.
 
-A single JSON object is returned, with, at minimum, the `id` field set, to
-uniquely identify the uploaded media:
+Optionally, a thumbnail file path may also be included.
+
+A single JSON object is returned, with the base `id`, the original image's ID, and, if a thumbnail as given, the thumbnail ID:
 
 ```json
 {
-  "id": "225961fb85d82312e8c0ed511",
-  "type": "image/jpg"
+  "id": "225961fb85d82312e8c0ed511.jpg",
+  "original": "original/225961fb85d82312e8c0ed511.jpg",
+  "thumbnail": "thumbnail/225961fb85d82312e8c0ed511.jpg"
 }
 ```
 
-#### `GET /media/:id`
+To fetch the thumbnail later, one would hit the route `GET /media/thumbnail/225961fb85d82312e8c0ed511.jpg`.
 
-Retrieve a piece of media (photos only for now) by its `id`.
+#### `GET /media/:type/:id`
+
+Retrieve a piece of media (photos only for now) by its `id`. Valid `type`s are `original` and `thumbnail`.
 
 ### Mapbox Styles & Tiles
 

--- a/api.js
+++ b/api.js
@@ -246,15 +246,21 @@ Api.prototype.mediaGet = function (req, res, m) {
       res.statusCode = 404
       res.end()
     } else {
-      res.setHeader('content-type', 'image/jpeg')
+      if (m.id.endsWith('.jpg')) res.setHeader('content-type', 'image/jpeg')
+      else if (m.id.endsWith('.png')) res.setHeader('content-type', 'image/png')
       self.media.createReadStream(id).pipe(res)
     }
   })
 }
 
 Api.prototype.mediaPut = function (req, res, m, q) {
-  if (!fs.existsSync(q.file)) {
-    res.statusCode = 404
+  if (!q.file || !fs.existsSync(q.file)) {
+    res.statusCode = 400
+    res.end()
+    return
+  }
+  if (q.thumbnail && !fs.existsSync(q.thumbnail)) {
+    res.statusCode = 400
     res.end()
     return
   }
@@ -274,27 +280,35 @@ Api.prototype.mediaPut = function (req, res, m, q) {
       .once('error', cb)
   }
 
+  var pending = 1
+  if (q.thumbnail) pending++
+
+  // Copy original media
   copyFileTo(q.file, mediaPath, function (err) {
     if (err) {
       res.statusCode = 500
       res.end(err.toString())
       return
     }
+    if (!--pending) done()
+  })
 
-    if (!q.thumbnail) {
-      res.end(JSON.stringify({id: id, original: mediaPath}))
-      return
-    }
-
+  // Copy thumbnail
+  if (q.thumbnail) {
     copyFileTo(q.thumbnail, thumbnailPath, function (err) {
       if (err) {
         res.statusCode = 500
         res.end(err.toString())
         return
       }
-      res.end(JSON.stringify({id: id, original: mediaPath, thumbnail: thumbnailPath}))
+      if (!--pending) done()
     })
-  })
+  }
+
+  function done () {
+    if (pending) return
+    res.end(JSON.stringify({id: id}))
+  }
 }
 
 // Tiles

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (osm, media, opts) {
   router.addRoute('GET /presets/:id/*',        api.presetsGet.bind(api))
 
   // Media
-  router.addRoute('GET /media/:id',            api.mediaGet.bind(api))
+  router.addRoute('GET /media/:type/:id',      api.mediaGet.bind(api))
   router.addRoute('PUT /media',                api.mediaPut.bind(api))
 
   // Styles 'n Tiles

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "type": "git",
     "url": "git+https://github.com/digidem/mapeo-server.git"
   },
-  "author": "Karissa McKelvey",
+  "author": [
+    "Karissa McKelvey",
+    "Stephen Whitmore"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/digidem/mapeo-server/issues"
@@ -31,6 +34,7 @@
     "concat-stream": "^1.6.2",
     "hyperquest": "^2.1.3",
     "memdb": "^1.3.1",
+    "nyc": "^12.0.2",
     "osm-p2p": "^2.0.0",
     "osm-p2p-mem": "^1.0.0",
     "safe-fs-blob-store": "0.0.2",

--- a/test/media.js
+++ b/test/media.js
@@ -20,14 +20,55 @@ test('media: upload + get', function (t) {
     // response content
     hq.pipe(concat({ encoding: 'string' }, function (body) {
       var obj = JSON.parse(body)
-      t.ok(/^[0-9A-Fa-f]+$/.test(obj.id), 'expected media id response')
+      t.ok(/^original\/[0-9A-Fa-f]+.jpg$/.test(obj.original), 'expected media id response')
+      t.notOk(obj.thumbnail, 'thumbnail id not set')
+
+      var data = fs.readFileSync('test/data/image.jpg')
+      hq = hyperquest.get(base + '/media/' + obj.original)
+      hq.once('response', function (res) {
+        t.equal(res.statusCode, 200, 'get 200 ok')
+        t.equal(res.headers['content-type'], 'image/jpeg', 'type correct')
+        res.pipe(concat(function (buf) {
+          t.equals(buf.toString('hex'), data.toString('hex'), 'image data matches')
+          server.close()
+          t.end()
+        }))
+      })
+    }))
+
+    // request
+    hq.end()
+  })
+})
+
+test('media: upload + get with thumbnail', function (t) {
+  createServer(function (server, base, osm, media) {
+    var fpath = encodeURIComponent('test/data/image.jpg')
+    var href = base + '/media?file=' + fpath + '&thumbnail=' + fpath
+
+    var hq = hyperquest.put(href, {})
+
+    // http response
+    hq.once('response', function (res) {
+      t.equal(res.statusCode, 200, 'create 200 ok')
+      t.equal(res.headers['content-type'], 'application/json', 'type correct')
+    })
+
+    // response content
+    hq.pipe(concat({ encoding: 'string' }, function (body) {
+      var obj = JSON.parse(body)
+      t.ok(/^original\/[0-9A-Fa-f]+.jpg$/.test(obj.original), 'expected media id response')
+      t.ok(/^thumbnail\/[0-9A-Fa-f]+.jpg$/.test(obj.thumbnail), 'expected thumbnail id response')
 
       var buf1 = fs.readFileSync('test/data/image.jpg')
-      media.createReadStream(obj.id).pipe(concat(function (buf2) {
+      media.createReadStream(obj.original).pipe(concat(function (buf2) {
         t.equals(buf1.toString('hex'), buf2.toString('hex'))
+        media.createReadStream(obj.original).pipe(concat(function (buf3) {
+          t.equals(buf1.toString('hex'), buf3.toString('hex'))
 
-        server.close()
-        t.end()
+          server.close()
+          t.end()
+        }))
       }))
     }))
 

--- a/test/media.js
+++ b/test/media.js
@@ -20,11 +20,10 @@ test('media: upload + get', function (t) {
     // response content
     hq.pipe(concat({ encoding: 'string' }, function (body) {
       var obj = JSON.parse(body)
-      t.ok(/^original\/[0-9A-Fa-f]+.jpg$/.test(obj.original), 'expected media id response')
-      t.notOk(obj.thumbnail, 'thumbnail id not set')
+      t.ok(/^[0-9A-Fa-f]+.jpg$/.test(obj.id), 'expected media id response')
 
       var data = fs.readFileSync('test/data/image.jpg')
-      hq = hyperquest.get(base + '/media/' + obj.original)
+      hq = hyperquest.get(base + '/media/original/' + obj.id)
       hq.once('response', function (res) {
         t.equal(res.statusCode, 200, 'get 200 ok')
         t.equal(res.headers['content-type'], 'image/jpeg', 'type correct')
@@ -57,13 +56,12 @@ test('media: upload + get with thumbnail', function (t) {
     // response content
     hq.pipe(concat({ encoding: 'string' }, function (body) {
       var obj = JSON.parse(body)
-      t.ok(/^original\/[0-9A-Fa-f]+.jpg$/.test(obj.original), 'expected media id response')
-      t.ok(/^thumbnail\/[0-9A-Fa-f]+.jpg$/.test(obj.thumbnail), 'expected thumbnail id response')
+      t.ok(/^[0-9A-Fa-f]+.jpg$/.test(obj.id), 'expected media id response')
 
       var buf1 = fs.readFileSync('test/data/image.jpg')
-      media.createReadStream(obj.original).pipe(concat(function (buf2) {
+      media.createReadStream('original/' + obj.id).pipe(concat(function (buf2) {
         t.equals(buf1.toString('hex'), buf2.toString('hex'))
-        media.createReadStream(obj.original).pipe(concat(function (buf3) {
+        media.createReadStream('thumbnail/' + obj.id).pipe(concat(function (buf3) {
           t.equals(buf1.toString('hex'), buf3.toString('hex'))
 
           server.close()


### PR DESCRIPTION
- Accept 'thumbnail' param & store that as well as original
  - write media to 'media/original/ID.jpg'
  - write thumbnail to 'medial/thumbnail/ID.jpg'
- Include original file extension on media ID
- Update README
- Support `GET /media/original/ID.jpg` and `GET /media/thumbnail/ID.jpg`
- Update media tests