### PR TITLE
Update observations by version instead of ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Changed prop from `created_at_timestamp` to `timestamp`
+- Changed timestamp format from milliseconds since unix epoc to a UTC string (match the timestamp format of osm types)
+- More strict checking of observation properties on create and update
+
+
+[Unreleased]: https://github.com/digidem/mapeo-server/compare/v7.0.3...HEAD

--- a/README.md
+++ b/README.md
@@ -49,15 +49,13 @@ multiple results.
 
 #### `PUT /observations/:id`
 
-Update an observation by its `id` by providing a JSON object. Only the following fields can be modified:
+Update an observation by its `id` by providing a JSON object representing the new observation. `id` and `version` *must* be set. Only the following fields can be modified:
 
 - `lat`
 - `lon`
 - `ref`
 - `attachments`
 - `tags`
-
-If there are multiple heads for the element at `id`, only the head with the newest timestamp will be modified.
 
 #### `PUT /observations/to-element/:id`
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ Usually there will only be one result, but in forking situations (e.g. two
 devices create offline edits of the same observation then sync) there can be
 multiple results.
 
-#### `PUT /observations/:version`
+#### `PUT /observations/:id`
 
-Update an observation by its `version` by providing a JSON object. Only the following fields can be modified:
+Update an observation by its `id` by providing a JSON object. Only the following fields can be modified:
 
 - `lat`
 - `lon`
 - `ref`
 - `attachments`
 - `tags`
+
+If there are multiple heads for the element at `id`, only the head with the newest timestamp will be modified.
 
 #### `PUT /observations/to-element/:id`
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ observation. The following fields are required:
 
 The object will be returned, with the fields `id` and `timestamp` set.
 
+The property `ref` can also be optionally set, to indicate that the observation *observes* the OSM element with ID `ref`.
+
 #### `GET /observations/:id`
 
 Fetch an observation by its `id`. An array of JSON objects will be returned.
@@ -45,10 +47,15 @@ Usually there will only be one result, but in forking situations (e.g. two
 devices create offline edits of the same observation then sync) there can be
 multiple results.
 
-#### `PUT /observations/:id`
+#### `PUT /observations/:version`
 
-Update an observation by its `id` by providing a JSON object. Any fields given
-will be replaced.
+Update an observation by its `version` by providing a JSON object. Only the following fields can be modified:
+
+- `lat`
+- `lon`
+- `ref`
+- `attachments`
+- `tags`
 
 #### `PUT /observations/to-element/:id`
 

--- a/api.js
+++ b/api.js
@@ -126,7 +126,7 @@ Api.prototype.observationUpdate = function (req, res, m) {
       }
       // link back to the previous observation
       var opts = {
-        links: m.version
+        links: [m.version]
       }
       var finalObs = Object.assign(oldObs, {
         lat: newObs.lat || oldObs.lat,

--- a/api.js
+++ b/api.js
@@ -82,22 +82,26 @@ Api.prototype.observationCreate = function (req, res, m) {
       res.end('couldnt parse body json: ' + err.toString())
       return
     }
+    try {
+      validateObservation(obs)
+    } catch (err) {
+      res.statusCode = 400
+      res.end('Invalid observation: ' + err.toString())
+    }
+    const newObs = whitelistProps(obs)
+    newObs.type = 'observation'
+    newObs.timestamp = (new Date().toISOString())
 
-    // TODO(noffle): add whitelist for specifically allowed properties
-
-    obs.type = 'observation'
-    obs.timestamp = (new Date().toISOString())
-
-    self.osm.create(obs, function (err, _, node) {
+    self.osm.create(newObs, function (err, _, node) {
       if (err) {
         res.statusCode = 500
         res.end('failed to create observation: ' + err.toString())
         return
       }
       res.setHeader('content-type', 'application/json')
-      obs.id = node.value.k
-      obs.version = node.key
-      res.end(JSON.stringify(obs))
+      newObs.id = node.value.k
+      newObs.version = node.key
+      res.end(JSON.stringify(newObs))
     })
   })
 }

--- a/api.js
+++ b/api.js
@@ -84,7 +84,7 @@ Api.prototype.observationCreate = function (req, res, m) {
     // TODO(noffle): add whitelist for specifically allowed properties
 
     obs.type = 'observation'
-    obs.created_at_timestamp = (new Date().getTime())
+    obs.timestamp = (new Date().toISOString())
 
     self.osm.create(obs, function (err, _, node) {
       if (err) {
@@ -133,7 +133,8 @@ Api.prototype.observationUpdate = function (req, res, m) {
         lon: newObs.lon || oldObs.lon,
         ref: newObs.ref || oldObs.ref,
         attachments: newObs.attachments || oldObs.attachments,
-        tags: newObs.tags || oldObs.attachments
+        tags: newObs.tags || oldObs.attachments,
+        timestamp: new Date().toISOString()
       })
       self.osm.put(id, finalObs, opts, function (err, node) {
         if (err) {

--- a/api.js
+++ b/api.js
@@ -130,6 +130,18 @@ Api.prototype.observationUpdate = function (req, res, m) {
         return
       }
 
+      if (typeof newObs.version !== 'string') {
+        res.statusCode = 400
+        res.end('the given observation must have a "version" set')
+        return
+      }
+
+      if (newObs.id !== m.id) {
+        res.statusCode = 400
+        res.end('the given observation\'s id doesn\'t match the id url param')
+        return
+      }
+
       try {
         validateObservation(newObs)
       } catch (err) {
@@ -138,16 +150,9 @@ Api.prototype.observationUpdate = function (req, res, m) {
         return
       }
 
-      var opts = {}
-
-      // Get the newest observation head by timestamp. Replace it by linking
-      // to its version.
-      if (heads.length > 1) {
-        old = heads.sort(function (a, b) {
-          return b.timestamp - a.timestamp
-        })[0]
+      var opts = {
+        links: [newObs.version]
       }
-      opts.links = [old.version]
 
       var finalObs = whitelistProps(newObs)
       finalObs.type = 'observation'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (osm, media, opts) {
   router.addRoute('GET /observations',         api.observationList.bind(api))
   router.addRoute('GET /observations/:id',     api.observationGet.bind(api))
   router.addRoute('POST /observations',        api.observationCreate.bind(api))
-  router.addRoute('PUT /observations/:id',     api.observationUpdate.bind(api))
+  router.addRoute('PUT /observations/:version',api.observationUpdate.bind(api))
   router.addRoute('DELETE /observations/:id',  api.observationDelete.bind(api))
   router.addRoute('PUT /observations/to-element/:id', api.observationConvert.bind(api))
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (osm, media, opts) {
   router.addRoute('GET /observations',         api.observationList.bind(api))
   router.addRoute('GET /observations/:id',     api.observationGet.bind(api))
   router.addRoute('POST /observations',        api.observationCreate.bind(api))
-  router.addRoute('PUT /observations/:version',api.observationUpdate.bind(api))
+  router.addRoute('PUT /observations/:id',     api.observationUpdate.bind(api))
   router.addRoute('DELETE /observations/:id',  api.observationDelete.bind(api))
   router.addRoute('PUT /observations/to-element/:id', api.observationConvert.bind(api))
 

--- a/test/observations.js
+++ b/test/observations.js
@@ -180,6 +180,42 @@ test('observations: update ref', function (t) {
   })
 })
 
+test('observations: update attachments', function (t) {
+  var original = {
+    lat: 1,
+    lon: 2,
+    type: 'observation',
+    attachments: [{
+      id: '12345.jpg',
+      type: 'image/jpeg'
+    }],
+    timestamp: new Date().toISOString()
+  }
+  var update = {
+    type: 'observation',
+    attachments: [{
+      id: '12345.jpg',
+      type: 'image/jpeg'
+    }, {
+      id: '56789.jpg',
+      type: 'image/jpeg'
+    }]
+  }
+  var expected = {
+    type: 'observation',
+    attachments: [{
+      id: '12345.jpg',
+      type: 'image/jpeg'
+    }, {
+      id: '56789.jpg',
+      type: 'image/jpeg'
+    }]
+  }
+  testUpdateObservation(t, original, update, expected, function () {
+    t.end()
+  })
+})
+
 test('observations: update tags', function (t) {
   var original = {
     lat: 1,

--- a/test/observations.js
+++ b/test/observations.js
@@ -23,7 +23,7 @@ test('observations: create', function (t) {
         var obj = JSON.parse(body)
         t.ok(obj.id, 'id field set')
         t.ok(obj.version, 'version field set')
-        t.ok(obj.created_at_timestamp, 'created_at_timestamp field set')
+        t.ok(obj.timestamp, 'timestamp field set')
       } catch (e) {
         t.error(e, 'json parsing exception!')
       }
@@ -43,7 +43,7 @@ test('observations: create + delete', function (t) {
       t.error(err)
       t.ok(obs.id, 'id field set')
       t.ok(obs.version, 'version field set')
-      t.ok(obs.created_at_timestamp, 'created_at_timestamp field set')
+      t.ok(obs.timestamp, 'timestamp field set')
 
       delJson(`${base}/observations/${obs.id}`, function (err) {
         t.error(err)
@@ -142,7 +142,7 @@ test('observations: update lat/lon', function (t) {
     lat: 1,
     lon: 2,
     type: 'observation',
-    created_at_timestamp: new Date().getTime()
+    timestamp: new Date().toISOString()
   }
   var update = {
     lat: 1.5,
@@ -151,8 +151,7 @@ test('observations: update lat/lon', function (t) {
   var expected = {
     lat: 1.5,
     lon: 2,
-    type: 'observation',
-    created_at_timestamp: original.created_at_timestamp
+    type: 'observation'
   }
   testUpdateObservation(t, original, update, expected, function () {
     t.end()
@@ -165,7 +164,7 @@ test('observations: update ref', function (t) {
     lon: 2,
     type: 'observation',
     ref: 12094,
-    created_at_timestamp: new Date().getTime()
+    timestamp: new Date().toISOString()
   }
   var update = {
     ref: 12111
@@ -174,8 +173,7 @@ test('observations: update ref', function (t) {
     lat: 1,
     lon: 2,
     type: 'observation',
-    ref: 12111,
-    created_at_timestamp: original.created_at_timestamp
+    ref: 12111
   }
   testUpdateObservation(t, original, update, expected, function () {
     t.end()
@@ -188,7 +186,7 @@ test('observations: update tags', function (t) {
     lon: 2,
     type: 'observation',
     tags: { hey: 'you' },
-    created_at_timestamp: new Date().getTime()
+    timestamp: new Date().toISOString()
   }
   var update = {
     tags: { foo: 'bar', hey: 'there' }
@@ -197,8 +195,7 @@ test('observations: update tags', function (t) {
     lat: 1,
     lon: 2,
     type: 'observation',
-    tags: { foo: 'bar', hey: 'there' },
-    created_at_timestamp: original.created_at_timestamp
+    tags: { foo: 'bar', hey: 'there' }
   }
   testUpdateObservation(t, original, update, expected, function () {
     t.end()
@@ -222,7 +219,7 @@ test('observations: create + convert', function (t) {
       lat: 1,
       lon: 2,
       type: 'observation',
-      created_at_timestamp: new Date().getTime()
+      timestamp: new Date().toISOString()
     }
     osm.create(og, function (err, id, node) {
       t.error(err)
@@ -356,6 +353,7 @@ function testUpdateObservation (t, orig, update, expected, cb) {
           var obsCopy = Object.assign({}, obs)
           delete obsCopy.id
           delete obsCopy.version
+          delete obsCopy.timestamp
           t.deepEquals(obsCopy, expected)
 
           var href = `${base}/observations/${obs.id}`

--- a/test/observations.js
+++ b/test/observations.js
@@ -209,7 +209,72 @@ test('observations: update with invalid id fails gracefully', function (t) {
       t.end()
     })
   })
+})
 
+test('observations: try to update with bad version', function (t) {
+  createServer(function (server, base, osm, media) {
+    var obs = {
+      type: 'observation',
+      lat: 5,
+      lon: 6
+    }
+    osm.create(obs, function (err, id, node) {
+      t.error(err)
+
+      var href = `${base}/observations/${id}`
+      var hq = hyperquest.put(href, {
+        headers: { 'content-type': 'application/json' }
+      })
+
+      var update = {
+        type: 'observation',
+        lat: 10,
+        lon: 12,
+        version: 'fake version',
+        id: id
+      }
+
+      hq.on('response', function (res) {
+        t.equal(res.statusCode, 400, 'bad request 400')
+        server.close(function () { t.end() })
+      })
+
+      hq.end(JSON.stringify(update))
+    })
+  })
+})
+
+test('observations: try to update with bad id', function (t) {
+  createServer(function (server, base, osm, media) {
+    var obs = {
+      type: 'observation',
+      lat: 5,
+      lon: 6
+    }
+    osm.create(obs, function (err, id, node) {
+      t.error(err)
+
+      var href = `${base}/observations/${id}`
+      var hq = hyperquest.put(href, {
+        headers: { 'content-type': 'application/json' }
+      })
+
+      var update = {
+        type: 'observation',
+        lat: 10,
+        lon: 12,
+        version: node.key,
+        id: 'fake id'
+      }
+
+      hq.on('response', function (res) {
+        t.equal(res.statusCode, 400, 'bad request 400')
+        server.close(function () { t.end() })
+      })
+
+      hq.end(JSON.stringify(update))
+    })
+  })
 })
 
 test('observations: create + convert', function (t) {

--- a/test/observations.js
+++ b/test/observations.js
@@ -337,7 +337,7 @@ function testUpdateObservation (t, orig, update, expected, cb) {
     osm.create(orig, function (err, id, node) {
       t.error(err)
 
-      var href = `${base}/observations/${node.key}`
+      var href = `${base}/observations/${id}`
       var hq = hyperquest.put(href, {
         headers: { 'content-type': 'application/json' }
       })

--- a/test/observations.js
+++ b/test/observations.js
@@ -146,7 +146,8 @@ test('observations: update lat/lon', function (t) {
   }
   var update = {
     lat: 1.5,
-    lon: 2
+    lon: 2,
+    type: 'observation'
   }
   var expected = {
     lat: 1.5,
@@ -167,11 +168,10 @@ test('observations: update ref', function (t) {
     timestamp: new Date().toISOString()
   }
   var update = {
+    type: 'observation',
     ref: 12111
   }
   var expected = {
-    lat: 1,
-    lon: 2,
     type: 'observation',
     ref: 12111
   }
@@ -189,11 +189,10 @@ test('observations: update tags', function (t) {
     timestamp: new Date().toISOString()
   }
   var update = {
+    type: 'observation',
     tags: { foo: 'bar', hey: 'there' }
   }
   var expected = {
-    lat: 1,
-    lon: 2,
     type: 'observation',
     tags: { foo: 'bar', hey: 'there' }
   }

--- a/test/observations.js
+++ b/test/observations.js
@@ -342,6 +342,9 @@ function testUpdateObservation (t, orig, update, expected, cb) {
         headers: { 'content-type': 'application/json' }
       })
 
+      update.version = node.key
+      update.id = id
+
       hq.on('response', function (res) {
         t.equal(res.statusCode, 200, 'create 200 ok')
         t.equal(res.headers['content-type'], 'application/json', 'type correct')


### PR DESCRIPTION
There's a lot going on here, but here are the highlights of the PR:

- observations are updated by version, not ID
- an updated observation now 'links' back to its parent
- observation update property whitelist (lat/lon/ref/tags/attachments)
- prevents id/version properties from accidentally being saved on update
- more observation update tests

Helps address https://github.com/digidem/mapeo-mobile/issues/90