### PR TITLE
use ref instead of tags.element_id

### DIFF
--- a/api.js
+++ b/api.js
@@ -194,10 +194,11 @@ Api.prototype.observationConvert = function (req, res, m) {
       return
     }
 
-    // 2. see if tags.element_id already present (short circuit)
+    // 2. see if ref already present (short circuit)
     var obs = obses[Object.keys(obses)[0]]
-    if (obs.tags && obs.tags.element_id) {
-      res.end(JSON.stringify({ id: obs.tags.element_id }))
+    if (obs.ref) {
+      console.log('obs.ref', obs.ref)
+      res.end(JSON.stringify({ id: obs.ref }))
       return
     }
 
@@ -214,7 +215,7 @@ Api.prototype.observationConvert = function (req, res, m) {
 
     // 4. modify observation tags
     obs.tags = obs.tags || {}
-    obs.tags.element_id = batch[0].key
+    obs.ref = batch[0].key
     batch.push({
       type: 'put',
       key: m.id,
@@ -228,7 +229,7 @@ Api.prototype.observationConvert = function (req, res, m) {
         res.end(JSON.stringify('failed to write new element & observation'))
         return
       }
-      res.end(JSON.stringify({ id: obs.tags.element_id }))
+      res.end(JSON.stringify({ id: obs.ref }))
     })
   })
 }

--- a/api.js
+++ b/api.js
@@ -197,7 +197,6 @@ Api.prototype.observationConvert = function (req, res, m) {
     // 2. see if ref already present (short circuit)
     var obs = obses[Object.keys(obses)[0]]
     if (obs.ref) {
-      console.log('obs.ref', obs.ref)
       res.end(JSON.stringify({ id: obs.ref }))
       return
     }

--- a/test/observations.js
+++ b/test/observations.js
@@ -329,10 +329,10 @@ test('observations: create + convert', function (t) {
         t.error(err)
         t.ok(elm.id)
 
-        // look up observation again + check for element_id tag
+        // look up observation again + check for ref
         getJson(`${base}/observations/${id}`, function (err, obses) {
           t.error(err)
-          t.equals(obses[0].tags.element_id, elm.id)
+          t.equals(obses[0].ref, elm.id)
 
           // look up element + check id
           getJson(`${base}/observations/${elm.id}`, function (err, theElms) {


### PR DESCRIPTION
```
on*
11:38 
<ddem-bot> <gregor> Looks good. May I suggest a slightly different way of how we store this: the `refs` root-level prop is for storing the link to the node, we can use that instead of `tags.element_id`.
11:39 
<karissa> ah makes sense
11:39 gregor i think this hasn't been used yet so it's a good time to change it .i'll open a pr
11:40 do you imagine refs being a list?
11:40 
<noffle> sww karissa: right now it's a string (on mapeo-server), but a list would be more flexible
11:40 
<ddem-bot> <gregor> I think I wrote the suggested spec as just `ref: string` but maybe is should be `refs: Array(string)` just in case we decide we do actually want an obs to link to multiple nodes (we probably don't)
11:40 
<karissa> hmm
11:41 
<noffle> sww karissa: +1 on what greg said re the new node being independent
11:41 
<karissa> what if one day if we implement a feature for arrays we just have to have a backwards compat check. is that ok?
11:41 
<noffle> sww btw karissa would coworking today be viable / useful to you? we could try to get your mobile setup working too
11:41 
<karissa> it might be confusing to have an array if we don't have any cases where that pops up yet
11:41 
<ddem-bot> <gregor> @substack originally wrote an osm-p2p-observations implementation that kept observation-links entirely separate (no props on either the node or observation) but maybe that is just added complexity
11:42 
<karissa> gregor that makes sense if we're doing something like a relational database style that is Many to Many
11:42 
<ddem-bot> <gregor> @karissa I can agree with that. Maybe stick with ref for now?
11:42 
<karissa> ok

```