### PR TITLE
Default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Creates a mapeo http server.
 `media` is an instance of [abstract-blob-store][abstract-blob-store]. In order to do sync correctly, it must be patched with a `list(cb)` method, or you can use a blob store that already supports this, like [safe-fs-blob-store][safe-fs-blob-store].
 
 Valid `opts` include
-- `staticRoot` (string): the filesystem path to serve static files, like styles and tiles from.
+- `staticRoot` (string): the filesystem path to serve static files, like styles
+  and tiles from.
+- `fallbackPresetsDir` (string): the filesystem path to serve as a fallback for
+  requests to `/presets` if no files exist in `staticRoot/presets`. Useful for
+  serving defaults that can be overridden by user files in `staticRoot`.
 
 ### var handled = server.handle(req, res)
 
@@ -298,4 +302,3 @@ Relies on `fs` for media copying right now: this is a bug.
 [kappa-osm]: https://github.com/digidem/kappa-osm
 [abstact-blob-store]: https://github.com/maxogden/abstract-blob-store
 [safe-fs-blob-store]: https://github.com/noffle/safe-fs-blob-store
-

--- a/test/presets.js
+++ b/test/presets.js
@@ -52,3 +52,28 @@ test('presets: get', function (t) {
     })
   })
 })
+
+test('presets: get default passthrough', function (t) {
+  createServer({
+    port: 5000,
+    fallbackPresetsDir: path.join(__dirname, '..', 'presets'),
+    staticRoot: __dirname
+  }, function (server, base) {
+    var expected = fs.readFileSync(path.join(__dirname, '..', 'presets', 'jungle', 'icons.svg'), 'utf-8')
+    var href = base + '/presets/jungle/icons.svg'
+    var hq = hyperquest.get(href)
+    hq.once('response', function (res) {
+      t.equal(res.statusCode, 200, 'get 200 ok')
+      t.ok(/image\/svg\+xml/.test(res.headers['content-type']), 'type correct')
+
+      hq.pipe(concat(function (body) {
+        t.equals(body.toString(), expected)
+        server.close()
+        t.end()
+      }))
+    })
+    hq.once('error', function (err) {
+      t.error(err, 'no http error')
+    })
+  })
+})

--- a/test/presets.js
+++ b/test/presets.js
@@ -53,6 +53,26 @@ test('presets: get', function (t) {
   })
 })
 
+test('presets: 404', function (t) {
+  createServer(function (server, base) {
+    var href = base + '/presets/unknown_id/missing.json'
+    var hq = hyperquest.get(href)
+    hq.once('response', function (res) {
+      t.equal(res.statusCode, 404, 'get 404 ok')
+      t.ok(/application\/json/.test(res.headers['content-type']), 'type correct')
+
+      hq.pipe(concat(function (body) {
+        t.deepEquals(JSON.parse(body.toString()), { error: 'Not Found', status: 404 })
+        server.close()
+        t.end()
+      }))
+    })
+    hq.once('error', function (err) {
+      t.error(err, 'no http error')
+    })
+  })
+})
+
 test('presets: get default passthrough', function (t) {
   createServer({
     port: 5000,

--- a/test/sync.js
+++ b/test/sync.js
@@ -69,7 +69,7 @@ test('sync - two-server listen and join and find eachother', function (t) {
         } catch (err) {
           t.fail('JSON parse failed: ' + data.toString())
         }
-        t.equal(body.message.length, 1)
+        t.equal(body.message.length, 1, 'message expected length')
         var entry = body.message[0]
         t.equal(entry.type, 'wifi')
         next()
@@ -80,7 +80,7 @@ test('sync - two-server listen and join and find eachother', function (t) {
       hq.on('error', function (err) { t.error(err) })
       hq.on('end', function () {
         destroy(a, b, function (err) {
-          t.error(err)
+          t.error(err, 'destroyed without error')
           a.server.close()
           b.server.close()
           t.end()
@@ -88,9 +88,9 @@ test('sync - two-server listen and join and find eachother', function (t) {
       })
     })
     listen(a, b, function (err) {
-      t.error(err)
+      t.error(err, 'server listening without error')
       join(a, b, function (err) {
-        t.error(err)
+        t.error(err, 'join without error')
       })
     })
   })


### PR DESCRIPTION
Adds a fallback to mapeo-default-settings (previously config-jungle) under the route `/presets/default` if no presets are in the user folder.

This is to support the way that Mapeo Mobile now handles presets. It expects a single set of presets on the `/presets/default` route (previously Mapeo Mobile read the list of presets from `/presets` and just chose the first one in that list). There is no UI for changing presets, and it doesn't make sense to do so, without also changing the whole database.

