### PR TITLE
Add preview images as well as thumbnail and original [BREAKING]

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,28 @@ Fetch a static file belonging to a preset with id `id`.
 
 ### Media
 
-#### `PUT /media?file=PATH&thumbnail=PATH`
+#### `POST /media`
 
-Save a piece of media (photos only) to the database, identified by the absolute
-file path `PATH` on the same machine as the server. `PATH` must be URL
-encoded.
+Save a photo to the database, expects a JSON object in the body of the request
+with the following properties:
 
-Optionally, a thumbnail file path may also be included.
+- `original` (string)
+- `preview` (string)
+- `thumbnail` (string)
+
+Each of these properties must be an absolute filepath pointing to the location
+of the media in the local filesystem. The files will be copied to the database
+and can be safely deleted once the request completes successfully. All 3 sizes
+are required and should be the following sizes:
+
+- *original*: full-size original media
+- *preview*: maximum dimension 2000px
+- *thumbnail*: maximum dimension 400px
+
+Original media is not syncronized between mobile devices, but previews and
+thumbnails are. Original media is always syncronized with desktop devices. In
+the future Mapeo may more intelligently manage full-size media in order to save
+space on mobile.
 
 A single JSON object is returned, with the media's unique `id`:
 
@@ -127,7 +142,8 @@ To fetch the thumbnail later, one would hit the route `GET /media/thumbnail/2259
 
 #### `GET /media/:type/:id`
 
-Retrieve a piece of media (photos only for now) by its `id`. Valid `type`s are `original` and `thumbnail`. e.g.
+Retrieve a piece of media (photos only for now) by its `id`. Valid `type`s are
+`original`, `preview` and `thumbnail`. e.g.
 
 ```
 GET /media/thumbnail/225961fb85d82312e8c0ed511.jpg
@@ -211,7 +227,7 @@ GET /sync/peers?interval=300
 
 ```
 
-A `StateObject` has a `topic` and `message` which give you an idea of what the current state 
+A `StateObject` has a `topic` and `message` which give you an idea of what the current state
 
 #### `GET /sync/start`
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (osm, media, opts) {
 
   // Media
   router.addRoute('GET /media/:type/:id', api.mediaGet.bind(api))
-  router.addRoute('PUT /media', api.mediaPut.bind(api))
+  router.addRoute('POST /media', api.mediaPost.bind(api))
 
   // Styles 'n Tiles
   router.addRoute('GET /styles', api.stylesList.bind(api))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@segment/isodate": "^1.0.3",
     "abstract-blob-store": "^3.3.4",
+    "collect-stream": "^1.2.1",
     "concat-stream": "^1.6.2",
     "dependency-check": "^3.3.0",
     "hyperquest": "^2.1.3",


### PR DESCRIPTION
- **BREAKING CHANGE**: Changes media route to POST instead of PUT, because PUT should be id-empotent, whereas this endpoint creates new resources for every POST.
- **BREAKING CHANGE**: Pass parameters in the body of the request, rather than query string, to avoid url encoding issues
- **BREAKING CHANGE**: Pass original as `original` property, rather than `file`
- **BREAKING CHANGE**: All 3 image sizes are required