### PR TITLE
chore: Run tests on Node versions used in apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
 - '8'
-- '10'
+- '10.13.0'
+- '12.4.0'
+- '12.14.1'
 os:
 - windows
 - osx

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       }
     },
     "@mapeo/core": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-8.2.1.tgz",
-      "integrity": "sha512-SbB/9dySbdG9f6IztFXh363HmniC2TABZWNu5pEggwxSOxroNkZRwwAzA0bk88wmpzX3bCYEjTjC9s/ZmZPDww==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@mapeo/core/-/core-8.2.2.tgz",
+      "integrity": "sha512-VgU7FKWYnT7yIFl6Amw1c2inTyp0vlLtzijMpvXPtTb7WG0G61O74xTT6NrfCD9uejAOfx3HUrEB8uJxWRhNmw==",
       "requires": {
         "blob-store-replication-stream": "^1.3.0",
         "concat-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/digidem/mapeo-server#readme",
   "dependencies": {
-    "@mapeo/core": "^8.2.1",
+    "@mapeo/core": "^8.2.2",
     "asar": "^2.0.1",
     "body": "^5.1.0",
     "debounce": "^1.2.0",

--- a/test/observations.js
+++ b/test/observations.js
@@ -471,10 +471,9 @@ function check (t, href, expected, done) {
   hq.pipe(concat({ encoding: 'string' }, function (body) {
     try {
       var objs = JSON.parse(body)
-      var sorter = (a, b) => a.id < b.id
       objs.forEach(obj => delete obj.timestamp)
       expected.forEach(obj => delete obj.timestamp)
-      t.deepEquals(objs.sort(sorter), expected.sort(sorter), 'observation from server matches expected')
+      t.deepEquals(objs.sort(idSort), expected.sort(idSort), 'observation from server matches expected')
     } catch (e) {
       t.error(e, 'json parsing exception!')
     }
@@ -560,4 +559,10 @@ function testUpdateObservation (t, orig, update, expected, cb) {
       hq.end(JSON.stringify(update))
     })
   })
+}
+
+function idSort (a, b) {
+  if (a.id < b.id) return -1
+  if (a.id > b.id) return +1
+  else return 0
 }


### PR DESCRIPTION
Mapeo Mobile currently runs on Node v10.13.0
Mapeo Desktop (electron v6.1.7) runs on Node v12.4.0
Latest electron is Node v12.14.1